### PR TITLE
Read OTEL_EXPORTER_OTLP_HEADERS On Syncer Create

### DIFF
--- a/zap_otlp_sync/zap_otlp_sync.go
+++ b/zap_otlp_sync/zap_otlp_sync.go
@@ -20,8 +20,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var otlpHeaders = os.Getenv("OTEL_EXPORTER_OTLP_HEADERS")
-
 type OtelSyncer struct {
 	ctx       context.Context
 	close     context.CancelFunc
@@ -46,6 +44,7 @@ type Options struct {
 }
 
 func NewOtlpSyncer(conn *grpc.ClientConn, options Options) *OtelSyncer {
+	otlpHeaders := os.Getenv("OTEL_EXPORTER_OTLP_HEADERS")
 	ctx, cancel := context.WithCancel(context.Background())
 
 	if options.BatchSize == 0 {


### PR DESCRIPTION
# Previously

The `OTEL_EXPORTER_OTLP_HEADERS` environment variable was read as module level global. This meant the variable could not be set after the application started - for example,  through godotenv. Attempting to do anything other than app start would cause 401 unauthorized errors.

# Now

It's read on syncer create - which fixes https://github.com/SigNoz/zap_otlp/issues/9


# Future
There should probably be an option to pass in the headers in case you do not want to use env variables