### PR TITLE
fix: add support for complex and interfaces

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -15,7 +15,7 @@ require (
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/sdk v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0
-	go.uber.org/zap v1.25.0
+	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.57.1
 )
 
@@ -26,7 +26,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
-	go.uber.org/goleak v1.2.1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,4 +1,3 @@
-github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
@@ -29,12 +28,11 @@ go.opentelemetry.io/otel/trace v1.16.0 h1:8JRpaObFoW0pxuVPapkgH8UhHQj+bJW8jJsCZE
 go.opentelemetry.io/otel/trace v1.16.0/go.mod h1:Yt9vYq1SdNz3xdjZZK7wcXv1qv2pwLkqr2QVwea0ef0=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
-go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
-go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-go.uber.org/zap v1.25.0 h1:4Hvk6GtkucQ790dqmj7l1eEnRdKm3k3ZUrUMS2d5+5c=
-go.uber.org/zap v1.25.0/go.mod h1:JIAUzQIH94IC4fOJQm7gMmBJP5k7wQfdcnYdPoEXJYk=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
 golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=

--- a/example/main.go
+++ b/example/main.go
@@ -50,7 +50,10 @@ func (a App) Hello(ctx context.Context, user string) error {
 	ctx, span = a.tracer.Start(ctx, "Hello")
 	defer span.End()
 
-	a.logger.Info("unamed: hello from the function to user: "+user, zap.String("user", user), zapotlp.SpanCtx(ctx), zap.Duration("duration", time.Second*2))
+	data := map[string]string{
+		"hello": "world",
+	}
+	a.logger.Info("unamed: hello from the function to user: "+user, zap.Any("test", data), zap.String("user", user), zapotlp.SpanCtx(ctx), zap.Duration("duration", time.Second*2))
 	a.logger.Named("my").Info("my1: hello from the function to user: "+user, zap.String("user", user), zapotlp.SpanCtx(ctx), zap.Duration("duration", time.Second*2))
 	a.logger.Named("my1").Info("my2: hello from the function to user: "+user, zap.String("user", user), zapotlp.SpanCtx(ctx), zap.Duration("duration", time.Second*2))
 
@@ -125,7 +128,7 @@ func main() {
 
 	app := NewApp(tracer, logger)
 
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 1; i++ {
 		time.Sleep(1 * time.Second)
 		app.Hello(ctx, strconv.Itoa(i)+"user: xyz")
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	go.opentelemetry.io/otel/trace v1.16.0
-	go.uber.org/zap v1.25.0
+	go.uber.org/zap v1.27.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -7,9 +6,9 @@ go.opentelemetry.io/otel v1.16.0 h1:Z7GVAX/UkAXPKsy94IU+i6thsQS4nb7LviLpnaNeW8s=
 go.opentelemetry.io/otel v1.16.0/go.mod h1:vl0h9NUa1D5s1nv3A5vZOYWn8av4K8Ml6JDeHrT/bx4=
 go.opentelemetry.io/otel/trace v1.16.0 h1:8JRpaObFoW0pxuVPapkgH8UhHQj+bJW8jJsCZEu5MQs=
 go.opentelemetry.io/otel/trace v1.16.0/go.mod h1:Yt9vYq1SdNz3xdjZZK7wcXv1qv2pwLkqr2QVwea0ef0=
-go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-go.uber.org/zap v1.25.0 h1:4Hvk6GtkucQ790dqmj7l1eEnRdKm3k3ZUrUMS2d5+5c=
-go.uber.org/zap v1.25.0/go.mod h1:JIAUzQIH94IC4fOJQm7gMmBJP5k7wQfdcnYdPoEXJYk=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/zap_otlp_encoder/go.mod
+++ b/zap_otlp_encoder/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0
 	go.opentelemetry.io/proto/otlp v1.0.0
-	go.uber.org/zap v1.25.0
+	go.uber.org/zap v1.27.0
 	google.golang.org/protobuf v1.31.0
 )
 

--- a/zap_otlp_encoder/go.sum
+++ b/zap_otlp_encoder/go.sum
@@ -1,4 +1,3 @@
-github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
@@ -28,11 +27,11 @@ go.opentelemetry.io/otel/trace v1.16.0 h1:8JRpaObFoW0pxuVPapkgH8UhHQj+bJW8jJsCZE
 go.opentelemetry.io/otel/trace v1.16.0/go.mod h1:Yt9vYq1SdNz3xdjZZK7wcXv1qv2pwLkqr2QVwea0ef0=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
-go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-go.uber.org/zap v1.25.0 h1:4Hvk6GtkucQ790dqmj7l1eEnRdKm3k3ZUrUMS2d5+5c=
-go.uber.org/zap v1.25.0/go.mod h1:JIAUzQIH94IC4fOJQm7gMmBJP5k7wQfdcnYdPoEXJYk=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/zap_otlp_encoder/zap_otlp_encoder_test.go
+++ b/zap_otlp_encoder/zap_otlp_encoder_test.go
@@ -2,7 +2,6 @@ package zap_otlp_encoder
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -162,11 +161,11 @@ func TestOTLPEncodeEntry(t *testing.T) {
 			data := strings.Split(string(buf.Bytes()), "#SIGNOZ#")
 
 			// For debugging purpose uncomment the lines below
-			r := &lv1.LogRecord{}
-			err = proto.Unmarshal([]byte(data[1]), r)
-			So(err, ShouldBeNil)
-			fmt.Println(r)
-			fmt.Println(tt.expected)
+			// r := &lv1.LogRecord{}
+			// err = proto.Unmarshal([]byte(data[1]), r)
+			// So(err, ShouldBeNil)
+			// fmt.Println(r)
+			// fmt.Println(tt.expected)
 
 			d, err := proto.Marshal(tt.expected)
 			So(err, ShouldBeNil)

--- a/zap_otlp_encoder/zap_otlp_encoder_test.go
+++ b/zap_otlp_encoder/zap_otlp_encoder_test.go
@@ -2,6 +2,7 @@ package zap_otlp_encoder
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -84,9 +85,13 @@ func TestOTLPEncodeEntry(t *testing.T) {
 					{Key: "int32", Value: &cv1.AnyValue{Value: &cv1.AnyValue_IntValue{IntValue: 1}}},
 					{Key: "uintptr", Value: &cv1.AnyValue{Value: &cv1.AnyValue_IntValue{IntValue: 1}}},
 					{Key: "a_float32", Value: &cv1.AnyValue{Value: &cv1.AnyValue_DoubleValue{DoubleValue: 2.7100000381469727}}},
-
-					// TODO: complex/array/object support to be added
-					// {Key: "complex_value", Value: &cv1.AnyValue{Value: &cv1.AnyValue_StringValue{StringValue: "3.14-2.71i"}}},
+					{Key: "complex_value", Value: &cv1.AnyValue{Value: &cv1.AnyValue_StringValue{StringValue: "(3.14-2.71i)"}}},
+					{Key: "such", Value: &cv1.AnyValue{Value: &cv1.AnyValue_StringValue{
+						StringValue: "{\"aee\":\"lol\",\"bee\":123,\"cee\":0.9999,\"dee\":[{\"key\":\"pi\",\"val\":3.141592653589793},{\"key\":\"tau\",\"val\":6.283185307179586}]}",
+					}}},
+					{Key: "any", Value: &cv1.AnyValue{Value: &cv1.AnyValue_StringValue{StringValue: "{\"x\":\"y\"}"}}},
+					{Key: "any bar", Value: &cv1.AnyValue{Value: &cv1.AnyValue_StringValue{StringValue: "{\"key\":\"pi\",\"val\":3.141592653589793}"}}},
+					{Key: "any array bar", Value: &cv1.AnyValue{Value: &cv1.AnyValue_StringValue{StringValue: "[{\"key\":\"pi\",\"val\":3.141592653589793},{\"key\":\"tau\",\"val\":6.283185307179586}]"}}},
 				},
 			},
 			ent: zapcore.Entry{
@@ -102,8 +107,8 @@ func TestOTLPEncodeEntry(t *testing.T) {
 				zap.Int32("int32", 1),
 				zap.Uintptr("uintptr", uintptr(1)),
 				zap.Float32("a_float32", 2.71),
-				zap.Complex128("complex_value", 3.14-2.71i), // currently ignored by the encoder
-				zap.Reflect("such", foo{ // currently ignored by the encoder
+				zap.Complex128("complex_value", 3.14-2.71i),
+				zap.Reflect("such", foo{
 					A: "lol",
 					B: 123,
 					C: 0.9999,
@@ -111,6 +116,16 @@ func TestOTLPEncodeEntry(t *testing.T) {
 						{"pi", 3.141592653589793},
 						{"tau", 6.283185307179586},
 					},
+				}),
+				zap.Any("any", map[string]string{
+					"x": "y",
+				}),
+				zap.Any("any bar", bar{
+					"pi", 3.141592653589793,
+				}),
+				zap.Any("any array bar", []bar{
+					{"pi", 3.141592653589793},
+					{"tau", 6.283185307179586},
 				}),
 			},
 		},
@@ -147,11 +162,11 @@ func TestOTLPEncodeEntry(t *testing.T) {
 			data := strings.Split(string(buf.Bytes()), "#SIGNOZ#")
 
 			// For debugging purpose uncomment the lines below
-			// r := &lv1.LogRecord{}
-			// err = proto.Unmarshal([]byte(data[1]), r)
-			// So(err, ShouldBeNil)
-			// fmt.Println(r)
-			// fmt.Println(tt.expected)
+			r := &lv1.LogRecord{}
+			err = proto.Unmarshal([]byte(data[1]), r)
+			So(err, ShouldBeNil)
+			fmt.Println(r)
+			fmt.Println(tt.expected)
 
 			d, err := proto.Marshal(tt.expected)
 			So(err, ShouldBeNil)


### PR DESCRIPTION
Fixes https://github.com/SigNoz/zap_otlp/issues/14

Previously attributes like this didn't work
```
zap.Any("any", map[string]string{
	"x": "y",
}),
zap.Any("any bar", bar{
	"pi", 3.141592653589793,
}),
zap.Any("any array bar", []bar{
	{"pi", 3.141592653589793},
	{"tau", 6.283185307179586},
}),
```

Now it's marshalled
				 